### PR TITLE
Localize dates. Migration is required!

### DIFF
--- a/protected/migrations/m160413_114629_add_translations_817_828_months.php
+++ b/protected/migrations/m160413_114629_add_translations_817_828_months.php
@@ -1,0 +1,102 @@
+<?php
+
+class m160413_114629_add_translations_817_828_months extends CDbMigration
+{
+	public function safeUp()
+	{
+
+		$start = 817;
+		$category = 'month';
+
+		$arrUa[$start] = 'січня';
+		$arrRu[$start] = 'января';
+		$arrEn[$start] = 'January';
+
+		$arrUa[] = 'лютого';
+		$arrRu[] = 'февраля';
+		$arrEn[] = 'February';
+
+		$arrUa[] = 'березня';
+		$arrRu[] = 'марта';
+		$arrEn[] = 'March';
+
+		$arrUa[] = 'квітня';
+		$arrRu[] = 'апреля';
+		$arrEn[] = 'April';
+
+		$arrUa[] = 'травня';
+		$arrRu[] = 'мая';
+		$arrEn[] = 'May';
+
+		$arrUa[] = 'червня';
+		$arrRu[] = 'июля';
+		$arrEn[] = 'June';
+
+		$arrUa[] = 'липня';
+		$arrRu[] = 'июня';
+		$arrEn[] = 'July';
+
+		$arrUa[] = 'серпня';
+		$arrRu[] = 'августа';
+		$arrEn[] = 'August';
+
+		$arrUa[] = 'вересня';
+		$arrRu[] = 'сентября';
+		$arrEn[] = 'September';
+
+		$arrUa[] = 'жовтня';
+		$arrRu[] = 'октября';
+		$arrEn[] = 'October';
+
+		$arrUa[] = 'листопада';
+		$arrRu[] = 'ноября';
+		$arrEn[] = 'November';
+
+		$arrUa[] = 'грудня';
+		$arrRu[] = 'декабря';
+		$arrEn[] = 'December';
+
+		for($i = $start; $i < $start + count($arrUa); $i++)
+		{
+			$this->insertMultiple('sourcemessages', array(
+				array(
+					'id' => $i,
+					'category' => $category,
+					'message' => '0'.$i
+				)));
+
+
+			$this->insertMultiple('translate', array(
+				array(
+					'id_record' => null,
+					'id' => $i,
+					'language' => 'ua',
+					'translation' => $arrUa[$i]
+				),
+				array(
+					'id_record' => null,
+					'id' => $i,
+					'language' => 'ru',
+					'translation' => $arrRu[$i]
+				),
+				array(
+					'id_record' => null,
+					'id' => $i,
+					'language' => 'en',
+					'translation' => $arrEn[$i]
+				)));
+		}
+	}
+
+	public function safeDown()
+	{
+		$start = 817;
+		$end = 828;
+
+		for($i = $start; $i <= $end; $i++)
+		{
+			$this->delete('translate', 'id='.$i);
+			$this->delete('sourcemessages', 'id='.$i);
+		}
+	}
+}

--- a/protected/views/graduate/_graduateBlock.php
+++ b/protected/views/graduate/_graduateBlock.php
@@ -12,7 +12,9 @@
             <td style="padding-left: 10px;">
                 <div class="text">
                     <?php echo Yii::t('graduates', '0320')?>
-                    <span><?php echo $data->graduate_date; ?></span>
+                    <span><?php $explodingDate = explode("-", $data->graduate_date); echo $explodingDate[2].' ' //variable explodingDate is using for separating month because localization used for month only
+                            .Yii::t('month', '0'.($explodingDate[1]+816)) //'816' is const which using for access to message ID in DB with translates examples, where january is 817, etc.
+                            .' '.$explodingDate[0]; ?></span>
                 </div>
                 <div class="text1"><?php echo $data->name(); ?></div>
                 <?php if(!empty($data->recall)){?>


### PR DESCRIPTION
Changes:
1. Use localized date formats in '/graduate' tab;
2. Translates messages placed within database (tables 'translate' and 'sourcemessages');
3. Create migration (required);